### PR TITLE
Rename String and Void classes

### DIFF
--- a/src/POData/ObjectModel/ODataURL.php
+++ b/src/POData/ObjectModel/ODataURL.php
@@ -2,7 +2,7 @@
 
 namespace POData\ObjectModel;
 
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 
 /**
  * Class ODataURL Represents top level link

--- a/src/POData/ObjectModel/ObjectModelSerializer.php
+++ b/src/POData/ObjectModel/ObjectModelSerializer.php
@@ -15,7 +15,7 @@ use POData\Providers\Metadata\ResourceProperty;
 use POData\Providers\ProvidersWrapper;
 use POData\Providers\Metadata\Type\Binary;
 use POData\Providers\Metadata\Type\Boolean;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\DateTime;
 use POData\Common\ODataException;
 use POData\Common\Messages;

--- a/src/POData/Providers/Metadata/ResourceType.php
+++ b/src/POData/Providers/Metadata/ResourceType.php
@@ -14,7 +14,7 @@ use POData\Providers\Metadata\Type\Int32;
 use POData\Providers\Metadata\Type\Int64;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
 use POData\Providers\Metadata\Type\EdmPrimitiveType;
 use POData\Providers\Metadata\Type\IType;
@@ -911,7 +911,7 @@ class ResourceType
             break;
         case EdmPrimitiveType::STRING:
             return new ResourceType(
-                new String(), 
+                new StringType(),
                 ResourceTypeKind::PRIMITIVE, 
                 'String', 'Edm'
             );

--- a/src/POData/Providers/Metadata/Type/StringType.php
+++ b/src/POData/Providers/Metadata/Type/StringType.php
@@ -3,10 +3,10 @@
 namespace POData\Providers\Metadata\Type;
 
 /**
- * Class String
+ * Class StringType
  * @package POData\Providers\Metadata\Type
  */
-class String implements IType
+class StringType implements IType
 {
     /**
      * Gets the type code

--- a/src/POData/Providers/Metadata/Type/VoidType.php
+++ b/src/POData/Providers/Metadata/Type/VoidType.php
@@ -5,10 +5,10 @@ namespace POData\Providers\Metadata\Type;
 use POData\Common\NotImplementedException;
 
 /**
- * Class Void
+ * Class VoidType
  * @package POData\Providers\Metadata\Type
  */
-class Void implements IType
+class VoidType implements IType
 {
     /**
      * Gets the type code

--- a/src/POData/UriProcessor/QueryProcessor/ExpressionParser/ExpressionParser.php
+++ b/src/POData/UriProcessor/QueryProcessor/ExpressionParser/ExpressionParser.php
@@ -8,7 +8,7 @@ use POData\Common\ODataException;
 use POData\Providers\Metadata\Type\Boolean;
 use POData\Providers\Metadata\Type\DateTime;
 use POData\Providers\Metadata\Type\Decimal;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\Int64;
 use POData\Providers\Metadata\Type\Int32;
 use POData\Providers\Metadata\Type\Double;
@@ -374,7 +374,7 @@ class ExpressionParser
         case ExpressionTokenId::IDENTIFIER:
             return $this->_parseIdentifier();
         case ExpressionTokenId::STRING_LITERAL:
-            return $this->_parseTypedLiteral(new String());
+            return $this->_parseTypedLiteral(new StringType());
         case ExpressionTokenId::INT64_LITERAL:
             return $this->_parseTypedLiteral(new Int64());
         case ExpressionTokenId::INTEGER_LITERAL:
@@ -660,7 +660,7 @@ class ExpressionParser
         //Will make these comparison as function calls, which will 
         // be converted to language specific function call by expression 
         // provider
-        $string = new String();
+        $string = new StringType();
         if ($left->typeIs($string) && $right->typeIs($string)) {
             $strcmpFunctions = FunctionDescription::stringComparisonFunctions();
             $left = new FunctionCallExpression($strcmpFunctions[0], array($left, $right));

--- a/src/POData/UriProcessor/QueryProcessor/FunctionDescription.php
+++ b/src/POData/UriProcessor/QueryProcessor/FunctionDescription.php
@@ -15,9 +15,9 @@ use POData\Providers\Metadata\Type\Double;
 use POData\Providers\Metadata\Type\Decimal;
 use POData\Providers\Metadata\Type\DateTime;
 use POData\Providers\Metadata\Type\Int32;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\Boolean;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 use POData\Providers\Metadata\Type\Binary;
 use POData\Providers\Metadata\Type\IType;
 use POData\UriProcessor\QueryProcessor\ExpressionParser\Expressions\ExpressionType;
@@ -93,81 +93,81 @@ class FunctionDescription
                 array(
                     new FunctionDescription(
                         'endswith', new Boolean(),
-                        array(new String(), new String())
+                        array(new StringType(), new StringType())
                     )
                 ),
             'indexof'       =>
                 array(
                     new FunctionDescription(
                         'indexof', new Int32(),
-                        array(new String(), new String())
+                        array(new StringType(), new StringType())
                     )
                 ),
             'replace'       =>
                 array(
                     new FunctionDescription(
-                        'replace', new String(),
-                        array(new String(), new String(), new String())
+                        'replace', new StringType(),
+                        array(new StringType(), new StringType(), new StringType())
                     )
                 ),
             'startswith'    =>
                 array(
                     new FunctionDescription(
                         'startswith', new Boolean(),
-                        array(new String(), new String())
+                        array(new StringType(), new StringType())
                     )
                 ),
             'tolower'       =>
                 array(
                     new FunctionDescription(
-                        'tolower', new String(),
-                        array(new String())
+                        'tolower', new StringType(),
+                        array(new StringType())
                     )
                 ),
             'toupper'       =>
                 array(
                     new FunctionDescription(
-                        'toupper', new String(),
-                        array(new String())
+                        'toupper', new StringType(),
+                        array(new StringType())
                     )
                 ),
             'trim'          =>
                 array(
                     new FunctionDescription(
-                        'trim', new String(),
-                        array(new String())
+                        'trim', new StringType(),
+                        array(new StringType())
                     )
                 ),
             'substring'     =>
                 array(
                     new FunctionDescription(
-                        'substring', new String(),
-                        array(new String(), new Int32())
+                        'substring', new StringType(),
+                        array(new StringType(), new Int32())
                     ),
                     new FunctionDescription(
-                        'substring', new String(),
-                        array(new String(), new Int32(), new Int32())
+                        'substring', new StringType(),
+                        array(new StringType(), new Int32(), new Int32())
                     )
                 ),
             'substringof'   =>
                 array(
                     new FunctionDescription(
                         'substringof', new Boolean(),
-                        array(new String(), new String())
+                        array(new StringType(), new StringType())
                     )
                 ),
             'concat'        =>
                 array(
                     new FunctionDescription(
-                        'concat', new String(),
-                        array(new String(), new String())
+                        'concat', new StringType(),
+                        array(new StringType(), new StringType())
                     )
                 ),
             'length'        =>
                 array(
                     new FunctionDescription(
                         'length', new Int32(),
-                        array(new String())
+                        array(new StringType())
                     )
                 ),
             //DateTime functions
@@ -262,7 +262,7 @@ class FunctionDescription
         return array(
             new FunctionDescription(
                 'strcmp', new Int32(), 
-                array(new String(), new String())
+                array(new StringType(), new StringType())
             )
         );
     }

--- a/src/POData/UriProcessor/QueryProcessor/OrderByParser/OrderByLeafNode.php
+++ b/src/POData/UriProcessor/QueryProcessor/OrderByParser/OrderByLeafNode.php
@@ -4,7 +4,7 @@ namespace POData\UriProcessor\QueryProcessor\OrderByParser;
 
 use POData\UriProcessor\QueryProcessor\AnonymousFunction;
 use POData\Providers\Metadata\Type\Guid;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\DateTime;
 use POData\Providers\Metadata\ResourceProperty;
 use POData\Common\Messages;
@@ -145,7 +145,7 @@ class OrderByLeafNode extends OrderByBaseNode
         $type = $this->resourceProperty->getInstanceType();
         if ($type instanceof DateTime) {
             $code .= " \$result = strtotime($accessor1) - strtotime($accessor2);";
-        } else if ($type instanceof String) {
+        } else if ($type instanceof StringType) {
             $code .= " \$result = strcmp($accessor1, $accessor2);";
         } else if ($type instanceof Guid) {
             $code .= " \$result = strcmp($accessor1, $accessor2);";

--- a/src/POData/UriProcessor/QueryProcessor/SkipTokenParser/InternalSkipTokenInfo.php
+++ b/src/POData/UriProcessor/QueryProcessor/SkipTokenParser/InternalSkipTokenInfo.php
@@ -5,7 +5,7 @@ namespace POData\UriProcessor\QueryProcessor\SkipTokenParser;
 use POData\Providers\Metadata\Type\Guid;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\DateTime;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\ResourceType;
 use POData\UriProcessor\QueryProcessor\OrderByParser\InternalOrderByInfo;
 use POData\Common\Messages;

--- a/src/POData/UriProcessor/ResourcePathProcessor/SegmentParser/KeyDescriptor.php
+++ b/src/POData/UriProcessor/ResourcePathProcessor/SegmentParser/KeyDescriptor.php
@@ -9,7 +9,7 @@ use POData\Providers\Metadata\Type\Single;
 use POData\Providers\Metadata\Type\Int64;
 use POData\Providers\Metadata\Type\Double;
 use POData\Providers\Metadata\Type\Decimal;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\Guid;
 use POData\Providers\Metadata\Type\DateTime;
 use POData\Providers\Metadata\Type\Boolean;
@@ -480,7 +480,7 @@ class KeyDescriptor
             $outType = new Guid();
             break;
         case ExpressionTokenId::STRING_LITERAL:
-            $outType = new String();
+            $outType = new StringType();
             break;
         case ExpressionTokenId::INTEGER_LITERAL:
             $outType = new Int32();

--- a/tests/UnitTests/POData/Providers/Metadata/Type/BinaryTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/BinaryTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class BinaryTest extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class BinaryTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertFalse( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/BooleanTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/BooleanTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class BooleanTest extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class BooleanTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertFalse( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/ByteTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/ByteTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class ByteTest extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class ByteTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertFalse( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/CharTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/CharTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class CharTest extends \PHPUnit_Framework_TestCase {
 
@@ -87,8 +87,8 @@ class CharTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertFalse( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/DateTimeTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/DateTimeTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class DateTimeTest extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertFalse( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/DecimalTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/DecimalTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class DecimalTest extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class DecimalTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertTrue( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/DoubleTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/DoubleTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class DoubleTest extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class DoubleTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertTrue( $type->isCompatibleWith(new SByte()) );
 		$this->assertTrue( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/GuidTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/GuidTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class GuidTest extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class GuidTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertFalse( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/Int16Test.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/Int16Test.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class Int16Test extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class Int16Test extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertTrue( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/Int32Test.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/Int32Test.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class Int32Test extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class Int32Test extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertTrue( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/Int64Test.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/Int64Test.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class Int64Test extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class Int64Test extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertTrue( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/Null1Test.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/Null1Test.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class Null1Test extends \PHPUnit_Framework_TestCase {
 
@@ -89,8 +89,8 @@ class Null1Test extends \PHPUnit_Framework_TestCase {
 		$this->assertTrue( $type->isCompatibleWith(new Null1()) );
 		$this->assertFalse( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/SByteTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/SByteTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class SByteTest extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class SByteTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertTrue( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/SingleTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/SingleTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class SingleTest extends \PHPUnit_Framework_TestCase {
 
@@ -86,8 +86,8 @@ class SingleTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertTrue( $type->isCompatibleWith(new SByte()) );
 		$this->assertTrue( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/StringTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/StringTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class StringTest extends \PHPUnit_Framework_TestCase {
 
@@ -30,7 +30,7 @@ class StringTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function getAsIType()
 	{
-		return new String();
+		return new StringType();
 	}
 
 	public function testConstructorAndDefaultValues()
@@ -86,8 +86,8 @@ class StringTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertFalse( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertTrue( $type->isCompatibleWith(new String()) );
-		$this->assertFalse( $type->isCompatibleWith(new Void()) );
+		$this->assertTrue( $type->isCompatibleWith(new StringType()) );
+		$this->assertFalse( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/Metadata/Type/VoidTest.php
+++ b/tests/UnitTests/POData/Providers/Metadata/Type/VoidTest.php
@@ -19,9 +19,9 @@ use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Null1;
 use POData\Providers\Metadata\Type\SByte;
 use POData\Providers\Metadata\Type\Single;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\TypeCode;
-use POData\Providers\Metadata\Type\Void;
+use POData\Providers\Metadata\Type\VoidType;
 
 class VoidTest extends \PHPUnit_Framework_TestCase {
 
@@ -30,7 +30,7 @@ class VoidTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function getAsIType()
 	{
-		return new Void();
+		return new VoidType();
 	}
 
 	public function testConstructorAndDefaultValues()
@@ -87,8 +87,8 @@ class VoidTest extends \PHPUnit_Framework_TestCase {
 		$this->assertFalse( $type->isCompatibleWith(new Null1()) );
 		$this->assertFalse( $type->isCompatibleWith(new SByte()) );
 		$this->assertFalse( $type->isCompatibleWith(new Single()) );
-		$this->assertFalse( $type->isCompatibleWith(new String()) );
-		$this->assertTrue( $type->isCompatibleWith(new Void()) );
+		$this->assertFalse( $type->isCompatibleWith(new StringType()) );
+		$this->assertTrue( $type->isCompatibleWith(new VoidType()) );
 
 
 

--- a/tests/UnitTests/POData/Providers/ProvidersWrapperTest.php
+++ b/tests/UnitTests/POData/Providers/ProvidersWrapperTest.php
@@ -13,7 +13,7 @@ use POData\Configuration\EntitySetRights;
 use POData\Providers\Metadata\IMetadataProvider;
 use POData\Common\ODataException;
 use POData\Common\Messages;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Common\InvalidOperationException;
 use POData\Providers\Metadata\ResourceAssociationSet;
 use POData\Providers\Metadata\ResourceAssociationSetEnd;
@@ -535,7 +535,7 @@ class ProvidersWrapperTest extends PhockitoUnitTestCase
 	public function testGetTypes()
 	{
 		$fakeTypes = array(
-			new ResourceType(new String(), ResourceTypeKind::PRIMITIVE, "FakeType1" ),
+			new ResourceType(new StringType(), ResourceTypeKind::PRIMITIVE, "FakeType1" ),
 		);
 
 		Phockito::when($this->mockMetadataProvider->getTypes())
@@ -550,8 +550,8 @@ class ProvidersWrapperTest extends PhockitoUnitTestCase
 	public function testGetTypesDuplicateNames()
 	{
 		$fakeTypes = array(
-			new ResourceType(new String(), ResourceTypeKind::PRIMITIVE, "FakeType1" ),
-			new ResourceType(new String(), ResourceTypeKind::PRIMITIVE, "FakeType1" ),
+			new ResourceType(new StringType(), ResourceTypeKind::PRIMITIVE, "FakeType1" ),
+			new ResourceType(new StringType(), ResourceTypeKind::PRIMITIVE, "FakeType1" ),
 		);
 
 		Phockito::when($this->mockMetadataProvider->getTypes())

--- a/tests/UnitTests/POData/UriProcessor/QueryProcessor/ExpressionParser/ExpressionParserTest.php
+++ b/tests/UnitTests/POData/UriProcessor/QueryProcessor/ExpressionParser/ExpressionParserTest.php
@@ -9,7 +9,7 @@ use POData\Providers\Metadata\Type\Single;
 use POData\Providers\Metadata\Type\Decimal;
 use POData\Providers\Metadata\Type\DateTime;
 use POData\Providers\Metadata\Type\Binary;
-use POData\Providers\Metadata\Type\String;
+use POData\Providers\Metadata\Type\StringType;
 use POData\Providers\Metadata\Type\Navigation;
 use POData\Providers\Metadata\Type\Boolean;
 use POData\Providers\Metadata\Type\Null1;
@@ -149,7 +149,7 @@ class ExpressionParserTest extends \PHPUnit_Framework_TestCase
         $parser = new ExpressionParser($expression, $this->customersResourceType, false);
         $expr = $parser->parseFilter();
         $this->assertTrue($expr instanceof PropertyAccessExpression);
-        $this->assertTrue($expr->getType() instanceof String);
+        $this->assertTrue($expr->getType() instanceof StringType);
 
         $expression = 'Rating';
         $parser->resetParser($expression);
@@ -214,7 +214,7 @@ class ExpressionParserTest extends \PHPUnit_Framework_TestCase
                      false);
         $expr = $parser->parseFilter();
         $this->assertTrue($expr instanceof PropertyAccessExpression);
-        $this->assertTrue($expr->getType() instanceof String);
+        $this->assertTrue($expr->getType() instanceof StringType);
         $this->assertEquals('Edm.String', $expr->getResourceType()->getFullName());
 
         $expression = 'Customer/Orders/OrderID';
@@ -421,8 +421,8 @@ class ExpressionParserTest extends \PHPUnit_Framework_TestCase
         $paramExpression = $expr->getLeft()->getParamExpressions();
         $this->assertTrue($paramExpression[0] instanceof PropertyAccessExpression);
         $this->assertTrue($paramExpression[1] instanceof ConstantExpression);
-        $this->assertTrue($paramExpression[0]->getType() instanceof String);
-        $this->assertTrue($paramExpression[1]->getType() instanceof String);
+        $this->assertTrue($paramExpression[0]->getType() instanceof StringType);
+        $this->assertTrue($paramExpression[1]->getType() instanceof StringType);
         $this->assertTrue($expr->getRight() instanceof ConstantExpression);
         $this->assertEquals($expr->getRight()->getValue(), 0);
 


### PR DESCRIPTION
Rename String and Void classes because it's special class names in php 7